### PR TITLE
Make items only placeable on shelves

### DIFF
--- a/Assets/Prefabs/Shelf_01.prefab
+++ b/Assets/Prefabs/Shelf_01.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 6661917196110248267}
   m_Layer: 0
   m_Name: Shelf_01
-  m_TagString: Untagged
+  m_TagString: Shelf
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -90,10 +90,55 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: -8451223844352555540, guid: 28a05412846c07f4491cfd1626476c35,
+        type: 3}
+      propertyPath: m_TagString
+      value: Shelf
+      objectReference: {fileID: 0}
+    - target: {fileID: -5780950928546885950, guid: 28a05412846c07f4491cfd1626476c35,
+        type: 3}
+      propertyPath: m_TagString
+      value: Shelf
+      objectReference: {fileID: 0}
+    - target: {fileID: -5525249646320217000, guid: 28a05412846c07f4491cfd1626476c35,
+        type: 3}
+      propertyPath: m_TagString
+      value: Shelf
+      objectReference: {fileID: 0}
+    - target: {fileID: -4776810286014583467, guid: 28a05412846c07f4491cfd1626476c35,
+        type: 3}
+      propertyPath: m_TagString
+      value: Shelf
+      objectReference: {fileID: 0}
+    - target: {fileID: -760723947301089920, guid: 28a05412846c07f4491cfd1626476c35,
+        type: 3}
+      propertyPath: m_TagString
+      value: Shelf
+      objectReference: {fileID: 0}
+    - target: {fileID: -310824055941041989, guid: 28a05412846c07f4491cfd1626476c35,
+        type: 3}
+      propertyPath: m_TagString
+      value: Shelf
+      objectReference: {fileID: 0}
     - target: {fileID: 919132149155446097, guid: 28a05412846c07f4491cfd1626476c35,
         type: 3}
       propertyPath: m_Name
       value: Shelf_01
+      objectReference: {fileID: 0}
+    - target: {fileID: 919132149155446097, guid: 28a05412846c07f4491cfd1626476c35,
+        type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
+    - target: {fileID: 3719278231009666125, guid: 28a05412846c07f4491cfd1626476c35,
+        type: 3}
+      propertyPath: m_TagString
+      value: Shelf
+      objectReference: {fileID: 0}
+    - target: {fileID: 8365168192904467795, guid: 28a05412846c07f4491cfd1626476c35,
+        type: 3}
+      propertyPath: m_TagString
+      value: Shelf
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scripts/PlaceObject.cs
+++ b/Assets/Scripts/PlaceObject.cs
@@ -35,6 +35,16 @@ public class PlaceObject : MonoBehaviour
             return;
         }
 
+        // If the held object is a Stock item, restrict placement to shelves only
+        if (InventoryManager.Instance.HeldObject.type == PlacementType.Stock)
+        {
+            if (!hit.collider.CompareTag("Shelf"))
+            {
+                Debug.Log("Stock items can only be placed on shelves");
+                return;
+            }
+        }
+
         // places the object at the coordinates of the raycast hit
         // and becomes a child of placedObjects
         GameObject placedObject = Instantiate(InventoryManager.Instance.HeldObject.prefab, hit.point, Quaternion.identity, placedObjects.transform);

--- a/Assets/Scripts/PlaceObject.cs
+++ b/Assets/Scripts/PlaceObject.cs
@@ -29,6 +29,12 @@ public class PlaceObject : MonoBehaviour
         if (!Physics.Raycast(transform.position, transform.TransformDirection(Vector3.forward), out hit, 10)) // hard coded interaction distance (10)
             return;
 
+        if (Vector3.Angle(hit.normal, Vector3.up) > 5f) //angle threshhold to place objects on flat surfaces only
+        {
+            Debug.Log("Can't place object on non-flat surface");
+            return;
+        }
+
         // places the object at the coordinates of the raycast hit
         // and becomes a child of placedObjects
         GameObject placedObject = Instantiate(InventoryManager.Instance.HeldObject.prefab, hit.point, Quaternion.identity, placedObjects.transform);

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -3,7 +3,8 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - Shelf
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
I have updated the PlaceObject script to include a check to see if the stock item we are placing is being placed on a shelf object. I added a shelf tag, and excluded the shelf object specifically from this check so we can still place shelves specifically anywhere we want.