### PR TITLE
Creating Error Popup to inform players when they cannot place an object

### DIFF
--- a/Assets/Scripts/HUDManager.cs
+++ b/Assets/Scripts/HUDManager.cs
@@ -37,4 +37,9 @@ public class HUDManager : MonoBehaviour
     {
         moneyDisplay.text = $"${GameManager.Instance.Money}";
     }
+
+    //method to popup a message when an error occurs
+    private void ErrorPopup(string message){
+        
+    }
 }


### PR DESCRIPTION
Creating an error popup so that players are properly informed when they are attempting something impossible within the game.