### PR TITLE
Fix structure softlocking

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1499,6 +1499,7 @@ MonoBehaviour:
   buyButton: {fileID: 889053396}
   buyButtonValidColor: {r: 0.3372549, g: 0.8, b: 0.16078432, a: 1}
   buyButtonInvalidColor: {r: 0.63127446, g: 0.6950688, b: 0.7735849, a: 1}
+  structureLeftoverMoneyCount: 5
 --- !u!4 &586006309
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/StoreManager.cs
+++ b/Assets/Scripts/StoreManager.cs
@@ -182,11 +182,11 @@ public class StoreManager : MonoBehaviour
     {
         if (GameManager.Instance.Money < totalCost)
         {
-            StartCoroutine(DisplayErrorMessage("Too Expensive!"));
+            StartCoroutine(DisplayErrorMessage("Too expensive!"));
         }
         else if (WillSoftlock())
         {
-            StartCoroutine(DisplayErrorMessage("Womp Womp"));
+            StartCoroutine(DisplayErrorMessage("You need some stock!"));
         }
         else
         {


### PR DESCRIPTION
## Issue 
Players can softlock by spending all of their money on structures and not stock. Prevent them from doing that when there is no stock in their cart or inventory or out on shelves. (closes #79)

## Changes
There are now checks when you try to purchase something stopping you from buying too many non sellable items so that you can no longer by stock and softlock yourself.