### PR TITLE
Added automatic builds to hotfix branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - staging
+      - '**-hotfix-**'
 
 jobs:
   buildForAllSupportedPlatforms:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - staging
-      - '**-hotfix-**'
+      - '**hotfix**'
 
 jobs:
   buildForAllSupportedPlatforms:


### PR DESCRIPTION
## Issue
In the build job in GitHub workflows, it should automatically make builds for any branches that have 'hotfix' in the name. This will help us detect issues without having to build manually.

## Solution
Any branches with `hotfix` in the name should now made an automatic build when they get a push.

(closes #121)