### PR TITLE
 Update Total Cost colour when money is updated

### DIFF
--- a/Assets/Scripts/StoreManager.cs
+++ b/Assets/Scripts/StoreManager.cs
@@ -47,6 +47,7 @@ public class StoreManager : MonoBehaviour
     private void Start()
     {
         GameManager.Instance.OnMoneyChange.AddListener(UpdateMoneyText);
+        GameManager.Instance.OnMoneyChange.AddListener(UpdateMoneyColors);
     }
 
     // This toggles the state of the Store GUI (open or closed)


### PR DESCRIPTION
## Issue
When user is in shop. total cost colour will not change if items sell

## Solution
The `UpdateMoneyColors()` method has been added to the `OnMoneyChange` unity event so it will update whenever money is changed.

(closes #73)