### PR TITLE
Player moves slower when crouched

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -804,7 +804,7 @@ MonoBehaviour:
       m_Calls: []
   username: jeffrey
   password: BetterPassword24!
-  startingMoney: 999999
+  startingMoney: 20
 --- !u!4 &220861225
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -804,7 +804,7 @@ MonoBehaviour:
       m_Calls: []
   username: jeffrey
   password: BetterPassword24!
-  startingMoney: 20
+  startingMoney: 999999
 --- !u!4 &220861225
 Transform:
   m_ObjectHideFlags: 0
@@ -3969,6 +3969,16 @@ PrefabInstance:
       propertyPath: spawnpoint
       value: 
       objectReference: {fileID: 1876903003}
+    - target: {fileID: 6830794489188715879, guid: 671aa3d2f1b2d74468ca28aa9dd85b07,
+        type: 3}
+      propertyPath: crouchAnimationSpeed
+      value: 13.12
+      objectReference: {fileID: 0}
+    - target: {fileID: 6830794489188715879, guid: 671aa3d2f1b2d74468ca28aa9dd85b07,
+        type: 3}
+      propertyPath: crouchMoveSpeedMultiplier
+      value: 0.4
+      objectReference: {fileID: 0}
     - target: {fileID: 7439313883792136263, guid: 671aa3d2f1b2d74468ca28aa9dd85b07,
         type: 3}
       propertyPath: ghostObject

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -24,6 +24,7 @@ public class PlayerMovement : MonoBehaviour
     private float cameraTargetHeight;
     private Camera cam;
     private float jumpLastPressedTime;
+    private bool isCrouched;
 
     void Awake()
     {
@@ -32,6 +33,7 @@ public class PlayerMovement : MonoBehaviour
 
         standHeight = cam.transform.localPosition.y;
         cameraTargetHeight = standHeight;
+        isCrouched = false;
         jumpLastPressedTime = Mathf.NegativeInfinity;
     }
 
@@ -106,6 +108,7 @@ public class PlayerMovement : MonoBehaviour
             cameraTargetHeight = standHeight - crouchDepth;
         else
             cameraTargetHeight = standHeight;
+        isCrouched = !isCrouched;
     }
     
     void HandleJumpInput()

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -54,6 +54,7 @@ public class PlayerMovement : MonoBehaviour
     {
         // handle walking movement (horizontal) ~ and prevent walking when in menu
         Vector2 moveInput = UIManager.Instance.IsGUIOpen ? Vector2.zero : moveAction.ReadValue<Vector2>() * moveSpeed;
+        if (isCrouched) moveInput *= crouchMoveSpeedMultiplier;
         Vector2.ClampMagnitude(moveInput, moveSpeed);
 
         // transform.forward and transform.right are forward/back & left/right motion respectively

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -12,7 +12,8 @@ public class PlayerMovement : MonoBehaviour
     [SerializeField][Range(1, 10)] private float jumpForce;
     [SerializeField][Range(0, 1)] private float jumpBufferTime; // used when jump is pressed before touching the ground
     [SerializeField][Range(0.1f, 2)] private float crouchDepth;
-    [SerializeField][Range(0.1f, 20)] private float crouchSpeed;
+    [SerializeField][Range(0.1f, 20)] private float crouchAnimationSpeed;
+    [SerializeField][Range(0.01f, 1)] private float crouchMoveSpeedMultiplier;
     [SerializeField] private Transform spawnpoint;
 
     private CharacterController cc;
@@ -73,7 +74,7 @@ public class PlayerMovement : MonoBehaviour
         cc.Move(moveVector * Time.deltaTime);
 
         // move camera towards target (crouched or standing) height, with an exponential ease
-        float cameraNewHeight = Mathf.Lerp(cam.transform.localPosition.y, cameraTargetHeight, crouchSpeed * Time.deltaTime);
+        float cameraNewHeight = Mathf.Lerp(cam.transform.localPosition.y, cameraTargetHeight, crouchAnimationSpeed * Time.deltaTime);
         cam.transform.localPosition = new Vector3(
             cam.transform.localPosition.x,
             cameraNewHeight,


### PR DESCRIPTION
## User Story
As a store owner, I want to be able to move slower, so that I can stock shelves more smoothly
As a player, I want crouching to slow my walk speed, because it is realistic and what I expect

## Issue
When the player is crouching, their move speed should be slower than when not crouching.
(closes #95)

## Fix Implemented
- Created a float to hold the speed multiplier, limited 0.01 to 1 (currently set at .4)
- Created bool to hold if the player is crouched
- Multiplied movement speed by crouch speed multiplier if player is crouched